### PR TITLE
Feature/compress vcf by gatk

### DIFF
--- a/src/main/scala/molmed/qscripts/DNABestPracticeVariantCalling.scala
+++ b/src/main/scala/molmed/qscripts/DNABestPracticeVariantCalling.scala
@@ -101,6 +101,9 @@ class DNABestPracticeVariantCalling extends QScript
   @Argument(fullName = "skip_annotation", shortName = "noAnnotation", doc = "Skip the snpEff annotation step", required = false)
   var skipAnnotation: Boolean = false
 
+  @Argument(fullName = "vcf_extension", shortName = "vcfExtension", doc = "VCF extension: 'vcf' (default) or 'vcf.gz'", required = false)
+  var vcfExtension: String = "vcf"
+
   @Argument(shortName = "mbq", doc = "The minimum Phred-Scaled quality score threshold to be considered a good base in variant calling", required = false)
   var minimumBaseQuality: Int = -1
 
@@ -243,7 +246,8 @@ class DNABestPracticeVariantCalling extends QScript
         isLowPass = this.isLowPass,
         isExome = this.isExome,
         testMode = this.testMode,
-        minimumBaseQuality = this.minimumBaseQuality)
+        minimumBaseQuality = this.minimumBaseQuality,
+        vcfExtension = this.vcfExtension)
     }
 
     /**
@@ -394,7 +398,8 @@ class DNABestPracticeVariantCalling extends QScript
       snpEffPath,
       snpEffConfigPath,
       Some(snpEffReference),
-      skipAnnotation)
+      skipAnnotation,
+      vcfExtension)
 
     variantCallingUtils.performVariantCalling(variantCallingConfig)
   }

--- a/src/main/scala/molmed/qscripts/DNABestPracticeVariantCalling.scala
+++ b/src/main/scala/molmed/qscripts/DNABestPracticeVariantCalling.scala
@@ -101,8 +101,8 @@ class DNABestPracticeVariantCalling extends QScript
   @Argument(fullName = "skip_annotation", shortName = "noAnnotation", doc = "Skip the snpEff annotation step", required = false)
   var skipAnnotation: Boolean = false
 
-  @Argument(fullName = "vcf_extension", shortName = "vcfExtension", doc = "VCF extension: 'vcf' (default) or 'vcf.gz'", required = false)
-  var vcfExtension: String = "vcf.gz"
+  @Argument(fullName = "skip_vcf_compression", shortName = "noCompress", doc = "Skip gz compression of vcf files", required = false)
+  var skipVcfCompression: Boolean = false
 
   @Argument(shortName = "mbq", doc = "The minimum Phred-Scaled quality score threshold to be considered a good base in variant calling", required = false)
   var minimumBaseQuality: Int = -1
@@ -247,7 +247,7 @@ class DNABestPracticeVariantCalling extends QScript
         isExome = this.isExome,
         testMode = this.testMode,
         minimumBaseQuality = this.minimumBaseQuality,
-        vcfExtension = this.vcfExtension)
+        skipVcfCompression = this.skipVcfCompression)
     }
 
     /**
@@ -399,7 +399,7 @@ class DNABestPracticeVariantCalling extends QScript
       snpEffConfigPath,
       Some(snpEffReference),
       skipAnnotation,
-      vcfExtension)
+      skipVcfCompression)
 
     variantCallingUtils.performVariantCalling(variantCallingConfig)
   }

--- a/src/main/scala/molmed/qscripts/DNABestPracticeVariantCalling.scala
+++ b/src/main/scala/molmed/qscripts/DNABestPracticeVariantCalling.scala
@@ -102,7 +102,7 @@ class DNABestPracticeVariantCalling extends QScript
   var skipAnnotation: Boolean = false
 
   @Argument(fullName = "vcf_extension", shortName = "vcfExtension", doc = "VCF extension: 'vcf' (default) or 'vcf.gz'", required = false)
-  var vcfExtension: String = "vcf"
+  var vcfExtension: String = "vcf.gz"
 
   @Argument(shortName = "mbq", doc = "The minimum Phred-Scaled quality score threshold to be considered a good base in variant calling", required = false)
   var minimumBaseQuality: Int = -1

--- a/src/main/scala/molmed/utils/AlignmentQCUtils.scala
+++ b/src/main/scala/molmed/utils/AlignmentQCUtils.scala
@@ -68,7 +68,7 @@ class AlignmentQCUtils(
     isExome: Boolean,
     testMode: Boolean,
     minimumBaseQuality: Option[Int],
-    vcfExtension: String): Seq[File] = {
+    skipVcfCompression: Boolean): Seq[File] = {
 
     val gatkOptionsWithGenotypingSnp = gatkOptions.copy(snpGenotypingVcf = Some(comparisonVcf))
     
@@ -87,7 +87,7 @@ class AlignmentQCUtils(
       minimumBaseQuality = minimumBaseQuality,
       noBAQ = true,
       skipAnnotation = true,
-      vcfExtension = vcfExtension)
+      skipVcfCompression = skipVcfCompression)
 
     val concordanceFiles = variantCallingUtils.checkGenotypeConcordance(variantCallingConfig)
     concordanceFiles

--- a/src/main/scala/molmed/utils/AlignmentQCUtils.scala
+++ b/src/main/scala/molmed/utils/AlignmentQCUtils.scala
@@ -67,7 +67,8 @@ class AlignmentQCUtils(
     isLowPass: Boolean,
     isExome: Boolean,
     testMode: Boolean,
-    minimumBaseQuality: Option[Int]): Seq[File] = {
+    minimumBaseQuality: Option[Int],
+    vcfExtension: String): Seq[File] = {
 
     val gatkOptionsWithGenotypingSnp = gatkOptions.copy(snpGenotypingVcf = Some(comparisonVcf))
     
@@ -85,7 +86,8 @@ class AlignmentQCUtils(
       testMode = testMode,
       minimumBaseQuality = minimumBaseQuality,
       noBAQ = true,
-      skipAnnotation = true)
+      skipAnnotation = true,
+      vcfExtension = vcfExtension)
 
     val concordanceFiles = variantCallingUtils.checkGenotypeConcordance(variantCallingConfig)
     concordanceFiles

--- a/src/main/scala/molmed/utils/VariantCallingConfig.scala
+++ b/src/main/scala/molmed/utils/VariantCallingConfig.scala
@@ -33,7 +33,7 @@ case object GATKHaplotypeCaller extends VariantCallerOption
  * @param snpEffConfigPath  Path to snpEff config file
  * @param snpEffReference   The snpEff reference to use. E.g. "GRCh37.75"
  * @param skipAnnotation   Skip the annotation process
- * @param vcfExtension     Extension of generated vcf files
+ * @param skipVcfCompression    Skip compression of generated vcf files
  */
 case class VariantCallingConfig(qscript: QScript,
 								variantCaller: Option[VariantCallerOption] = Some(GATKHaplotypeCaller),
@@ -54,4 +54,4 @@ case class VariantCallingConfig(qscript: QScript,
                                 snpEffConfigPath: Option[File] = None,
                                 snpEffReference: Option[String] = None,
                                 skipAnnotation: Boolean,
-                                vcfExtension: String = "vcf")
+                                skipVcfCompression: Boolean)

--- a/src/main/scala/molmed/utils/VariantCallingConfig.scala
+++ b/src/main/scala/molmed/utils/VariantCallingConfig.scala
@@ -33,6 +33,7 @@ case object GATKHaplotypeCaller extends VariantCallerOption
  * @param snpEffConfigPath  Path to snpEff config file
  * @param snpEffReference   The snpEff reference to use. E.g. "GRCh37.75"
  * @param skipAnnotation   Skip the annotation process
+ * @param vcfExtension     Extension of generated vcf files
  */
 case class VariantCallingConfig(qscript: QScript,
 								variantCaller: Option[VariantCallerOption] = Some(GATKHaplotypeCaller),
@@ -52,4 +53,5 @@ case class VariantCallingConfig(qscript: QScript,
                                 snpEffPath: Option[File] = None,
                                 snpEffConfigPath: Option[File] = None,
                                 snpEffReference: Option[String] = None,
-                                skipAnnotation: Boolean)
+                                skipAnnotation: Boolean,
+                                vcfExtension: String = "vcf")

--- a/src/main/scala/molmed/utils/VariantCallingTarget.scala
+++ b/src/main/scala/molmed/utils/VariantCallingTarget.scala
@@ -13,17 +13,19 @@ class VariantCallingTarget(outputDir: File,
                            val isLowpass: Boolean,
                            val isExome: Boolean,
                            val nSamples: Int,
-                           val snpGenotypingVcf: Option[File] = None) {
+                           val snpGenotypingVcf: Option[File] = None,
+                           val vcfExtension: String = "vcf") {
 
+  val vcfExt = if (vcfExtension.startsWith(".")) vcfExtension.tail else vcfExtension
   val name = outputDir + "/" + baseName
   val clusterFile = new File(name + ".clusters")
-  val gVCFFile = new File(name + ".genomic.vcf")
-  val rawSnpVCF = new File(name + ".raw.snp.vcf")
-  val rawIndelVCF = new File(name + ".raw.indel.vcf")
-  val rawCombinedVariants = new File(name + ".raw.vcf")
-  val filteredIndelVCF = new File(name + ".filtered.indel.vcf")
-  val recalibratedSnpVCF = new File(name + ".recalibrated.snp.vcf")
-  val recalibratedIndelVCF = new File(name + ".recalibrated.indel.vcf")
+  val gVCFFile = new File(name + ".genomic." + vcfExt)
+  val rawSnpVCF = new File(name + ".raw.snp." + vcfExt)
+  val rawIndelVCF = new File(name + ".raw.indel." + vcfExt)
+  val rawCombinedVariants = new File(name + ".raw." + vcfExt)
+  val filteredIndelVCF = new File(name + ".filtered.indel." + vcfExt)
+  val recalibratedSnpVCF = new File(name + ".recalibrated.snp." + vcfExt)
+  val recalibratedIndelVCF = new File(name + ".recalibrated.indel." + vcfExt)
   val tranchesSnpFile = new File(name + ".snp.tranches")
   val tranchesIndelFile = new File(name + ".indel.tranches")
   val vqsrSnpRscript: File = new File(name + ".snp.vqsr.r")
@@ -32,6 +34,5 @@ class VariantCallingTarget(outputDir: File,
   val recalIndelFile = new File(name + ".indel.tranches.recal")
   val evalFile = new File(name + ".snp.eval")
   val evalIndelFile = new File(name + ".indel.eval")
-  val genotypeConcordance = new File(name + ".genotypeconcordance.txt")  
-  
+  val genotypeConcordance = new File(name + ".genotypeconcordance.txt")
 }

--- a/src/main/scala/molmed/utils/VariantCallingTarget.scala
+++ b/src/main/scala/molmed/utils/VariantCallingTarget.scala
@@ -14,18 +14,18 @@ class VariantCallingTarget(outputDir: File,
                            val isExome: Boolean,
                            val nSamples: Int,
                            val snpGenotypingVcf: Option[File] = None,
-                           val vcfExtension: String = "vcf") {
+                           val skipVcfCompression: Boolean = true) {
 
-  val vcfExt = if (vcfExtension.startsWith(".")) vcfExtension.tail else vcfExtension
+  val vcfExtension = if (skipVcfCompression) "vcf" else "vcf.gz"
   val name = outputDir + "/" + baseName
   val clusterFile = new File(name + ".clusters")
-  val gVCFFile = new File(name + ".genomic." + vcfExt)
-  val rawSnpVCF = new File(name + ".raw.snp." + vcfExt)
-  val rawIndelVCF = new File(name + ".raw.indel." + vcfExt)
-  val rawCombinedVariants = new File(name + ".raw." + vcfExt)
-  val filteredIndelVCF = new File(name + ".filtered.indel." + vcfExt)
-  val recalibratedSnpVCF = new File(name + ".recalibrated.snp." + vcfExt)
-  val recalibratedIndelVCF = new File(name + ".recalibrated.indel." + vcfExt)
+  val gVCFFile = new File(name + ".genomic." + vcfExtension)
+  val rawSnpVCF = new File(name + ".raw.snp." + vcfExtension)
+  val rawIndelVCF = new File(name + ".raw.indel." + vcfExtension)
+  val rawCombinedVariants = new File(name + ".raw." + vcfExtension)
+  val filteredIndelVCF = new File(name + ".filtered.indel." + vcfExtension)
+  val recalibratedSnpVCF = new File(name + ".recalibrated.snp." + vcfExtension)
+  val recalibratedIndelVCF = new File(name + ".recalibrated.indel." + vcfExtension)
   val tranchesSnpFile = new File(name + ".snp.tranches")
   val tranchesIndelFile = new File(name + ".indel.tranches")
   val vqsrSnpRscript: File = new File(name + ".snp.vqsr.r")

--- a/src/main/scala/molmed/utils/VariantCallingUtils.scala
+++ b/src/main/scala/molmed/utils/VariantCallingUtils.scala
@@ -151,7 +151,7 @@ class VariantCallingUtils(gatkOptions: GATKConfig, projectName: Option[String], 
   def annotateUsingSnpEff(config: VariantCallingConfig, variantFiles: Seq[File]): Seq[File] = {
     val vcfExt = if (config.vcfExtension.startsWith(".")) config.vcfExtension.tail else config.vcfExtension
     for (file <- variantFiles) yield {
-      val annotatedFile = GeneralUtils.swapExt(file.getParentFile(), file, vcfExt, ".annotated." + vcfExt)
+      val annotatedFile = GeneralUtils.swapExt(file.getParentFile(), file, vcfExt, "annotated." + vcfExt)
       config.qscript.add(
         new SnpEff(file, annotatedFile, config))
       annotatedFile


### PR DESCRIPTION
- Implements vcf compression by specifying a `vcf.gz` extension for GATK and snpEff output files
- Can be disabled with the `--skip_vcf_compression` parameter to the `DNABestPracticeVariantCalling.scala` qscript
